### PR TITLE
Rwfus v0.5.0

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,6 @@
+# Important Note:
+Rwfus v0.5.0.b1 is *only* rated for compatibility with SteamOS 3.5 (Beta, at the time of writing)
+
 ## Rwfus: Read-Write OverlayFS for your Steam Deck!
 ---
 
@@ -9,7 +12,6 @@ Directories covered in a default installation:
 | /etc/pacman.d     | `pacman` configuration |
 | /usr              | Programs and libraries |
 | /var/cache/pacman | Package cache          |
-| /var/lib/pacman   | Package metadata       |
 
 ### * Jank warning
 
@@ -32,7 +34,7 @@ Then you're all set! Remember to periodically run `pacman -Sy` to update your re
 ### Usage:
 
 ```
-Rwfus v0.4.1
+Rwfus v0.5.0.b1
 Carry Pacman across SteamOS updates!
 
 USAGE:

--- a/rwfus
+++ b/rwfus
@@ -38,7 +38,7 @@ source "$IncludeDir/manage-install.sh" # Installation management
 source "$IncludeDir/config.sh"         # Configuration files
 
 # Load the default configuration.
-load_defaults
+config default
 
 # Default operation
 Default_Operation="stat_service "
@@ -114,11 +114,11 @@ while true; do
             shift
             ;;
         -u|--update)
-            Operation+="perform_update "
+            Operation+="perform_install "
             shift
             ;;
         -r|--remove)
-            Operation+="perform_remove_all "
+            Operation+="perform_remove "
             shift
             ;;
     # Enablement control operations
@@ -161,7 +161,7 @@ while true; do
     # Sample generators
         -g|--gen-config)
             sample_fullpath="$caller_dir/${Name@L}.conf"
-            config --store "$sample_fullpath"
+            config store "$sample_fullpath"
             echo "Wrote config to $sample_fullpath"
             exit 0
             ;;
@@ -193,7 +193,7 @@ while true; do
             shift 2
             ;;
         -c|--config)
-            config --load "$2"
+            config load "$2"
             shift 2
             ;;
 
@@ -219,17 +219,17 @@ function initialize_log {
 
 for operation in ${Operation:=$Default_Operation}; do
     case "$operation" in
-        "perform_install"|"perform_update"|"perform_remove_all"|\
+        "perform_install"|"perform_remove"|\
         "add_to_bin"|"remove_from_bin"|\
         "enable_service"|"disable_service")
             check_permissions
             initialize_log
-            Log config --load
+            Log config load
             $operation "$@"
         ;;
         "mount_disk"|"unmount_disk"|"backup_disk"|"restore_disk")
             check_permissions
-            config --load
+            config load
             state=$(service_state)
             echo "$state"
             if [[ "$state" == "active"* ]]; then
@@ -245,7 +245,7 @@ for operation in ${Operation:=$Default_Operation}; do
             fi
         ;;
         "stat_service"|"stat_disk")
-            config --load > /dev/null
+            config load > /dev/null
             $operation
         ;;
         "print_help")

--- a/rwfus_include/disk.sh
+++ b/rwfus_include/disk.sh
@@ -87,6 +87,12 @@ function update_disk_image {
         local escaped_dir; escaped_dir=$(systemd-escape -p -- "$dir")
         Log mkdir -pv -- "${cf_Upper_Directory}/${escaped_dir}" "${cf_Work_Directory}/${escaped_dir}"
     done
+    #? SteamOS 3.5 migration: Pacman DB location has been moved from /var/lib/pacman to /usr/lib/holo/pacmandb
+    if [[ -d "$cf_Upper_Directory/usr" && -d "$cf_Upper_Directory/var-lib-pacman" ]]; then
+        Target="${cf_Upper_Directory}/usr/lib/holo/pacmandb"
+        Log mkdir -pv -- "${Target}"
+        Log mv -- "$cf_Upper_Directory/var-lib-pacman/"* $Target
+    fi
     Log Test unmount_disk
 }
 

--- a/rwfus_include/info.sh
+++ b/rwfus_include/info.sh
@@ -3,4 +3,4 @@
 export Name="Rwfus"
 export Description="Carry Pacman across SteamOS updates!"
 export Repository="https://github.com/ValShaped/rwfus"
-export Version="0.4.2"
+export Version="0.5.0.b1"


### PR DESCRIPTION
# Update for SteamOS 3.5/3.6

This release is not compatible with SteamOS versions below 3.5. Versions below 3.5 have a variety of severe security vulnerabilities, so you should probably update your Deck.

## Breaking Changes
- The configuration file is now versioned, and will be migrated to use the latest settings upon updating. If this happens, you will be prompted to review the changes.
- The `--install-bin` and `--remove-bin` options have been removed entirely, as they proved to be unreliable. See the readme for instructions on doing that yourself. Fixes #48